### PR TITLE
fix(build): #26.1 pin dependencies

### DIFF
--- a/src/sorts/res/requirements.txt
+++ b/src/sorts/res/requirements.txt
@@ -1,6 +1,7 @@
-category-encoders
-gitpython
-tqdm
-prettytable
-cryptography
-typing-extensions
+category-encoders==2.3.0
+cryptography==36.0.1
+gitpython==3.1.27
+prettytable==3.1.1
+scikit-learn==0.23.2
+tqdm==4.62.3
+typing-extensions==4.1.1


### PR DESCRIPTION
- Specify the exact versions wanted for python packages
- Set scikit-learn version to 0.23.2 for compatibility with
  current model