### PR TITLE
feat(back): #28.3 disable unnecessary warnings

### DIFF
--- a/src/sorts/entrypoint.py
+++ b/src/sorts/entrypoint.py
@@ -167,6 +167,7 @@ def predict_vuln_prob(
     feature_quantity = len(feature_names)
 
     # Separate previous and current commit data
+    pd.options.mode.chained_assignment = None
     for feature in feature_names:
         prev_input_data[str(feature)] = prev_input_data[str(feature)].apply(
             lambda item: item[0]


### PR DESCRIPTION
- Disable some warnings that don't affect functionality
  to have a cleaner presentation